### PR TITLE
no age shaming

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "name": "Chrome Extension MV3",
     "description": "Building a Chrome Extension MV3",
     "version": "0.1.0",
-    "minimum_chrome_version": "116",
+    "minimum_chrome_version": "111",
     "manifest_version": 3,
     "icons": {
         "16": "icon.png",


### PR DESCRIPTION
if you fill in the blank, i can make another PR or commit like:  `chrome.runtime.onInstalled.addListener(function(installed){if(installed.reason=='install'){if 116 > Number(navigator.userAgent.match(new RegExp(Chrome|Firefox + '/([0-9]+)'))){alert("[Just to make sure:] Some of our features might require chrome version 116+.... _______________________") }`    ( - or rather add it precisely, when that feature is first enabled as indicated by its button or storage change.)